### PR TITLE
fix(deps): migrate pnpm overrides to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,17 +73,6 @@
     "vaul": "^1.1.2",
     "zod": "^4.3.5"
   },
-  "pnpm": {
-    "overrides": {
-      "minimatch": ">=3.1.3",
-      "flatted": ">=3.3.4",
-      "ajv": "^8.17.1",
-      "@eslint/eslintrc>ajv": "^6.12.6",
-      "eslint>ajv": "^6.12.6",
-      "@isaacs/brace-expansion": ">=2.0.0",
-      "qs": ">=6.14.0"
-    }
-  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  minimatch: '>=3.1.3'
+  flatted: '>=3.3.4'
+  ajv: ^8.17.1
+  '@eslint/eslintrc>ajv': ^6.12.6
+  eslint>ajv: ^6.12.6
+  '@isaacs/brace-expansion': '>=2.0.0'
+  qs: '>=6.14.0'
+
 importers:
 
   .:
@@ -2095,7 +2104,7 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: ^8.17.1
     peerDependenciesMeta:
       ajv:
         optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,3 +13,12 @@ onlyBuiltDependencies:
   - msw
   - unrs-resolver
   - "@tailwindcss/oxide"
+
+overrides:
+  minimatch: ">=3.1.3"
+  flatted: ">=3.3.4"
+  ajv: "^8.17.1"
+  "@eslint/eslintrc>ajv": "^6.12.6"
+  "eslint>ajv": "^6.12.6"
+  "@isaacs/brace-expansion": ">=2.0.0"
+  qs: ">=6.14.0"


### PR DESCRIPTION
## Why

pnpm 11+ **silently ignores** `pnpm.overrides` defined inside `package.json` at the workspace root. The block parses without error but has no effect on dependency resolution — so the 7 security overrides added in prior sweeps were dead config and the underlying CVEs were still live in `node_modules`.

## What

Moved the entire `pnpm.overrides` block (7 entries, including scoped `eslint>ajv`-style entries) from `package.json` into `pnpm-workspace.yaml` at top level. Removed the now-empty `pnpm` block from `package.json`. Existing `allowBuilds:` and `onlyBuiltDependencies:` blocks left intact.

## Verification

- `pnpm install --no-frozen-lockfile` regenerated the lockfile.
- `pnpm install --frozen-lockfile` passes.
- `pnpm run build` passes (`pnpm registry:build && next build`).
- `pnpm-lock.yaml` now contains a top-level `overrides:` block (previously missing). `minimatch` resolves to `10.2.5` (override `>=3.1.3`).

## Notes

Same migration applied across the rest of the portfolio repos that received overrides in earlier security sweeps. No app code changes — config only.